### PR TITLE
Check for use of `eval()` in PHP files

### DIFF
--- a/doctor.yml
+++ b/doctor.yml
@@ -19,6 +19,10 @@ cron-duplicates:
   class: runcommand\Doctor\Checks\Cron_Duplicates
 cron-count:
   class: runcommand\Doctor\Checks\Cron_Count
+file-eval:
+  class: runcommand\Doctor\Checks\File
+  options:
+    regex: eval\(.*base64_decode\(.*
 plugin-active-count:
   class: runcommand\Doctor\Checks\Plugin_Active_Count
 plugin-deactivated:

--- a/features/check-file.feature
+++ b/features/check-file.feature
@@ -1,0 +1,20 @@
+Feature: Check files in a WordPress install
+
+  Scenario: Check for use of eval(base64_decode()) in files
+    Given a WP install
+
+    When I run `wp doctor check file-eval`
+    Then STDOUT should be a table containing rows:
+      | name          | status    | message                                                       |
+      | file-eval     | success   | All 'php' files passed check for 'eval\(.*base64_decode\(.*'. |
+
+    Given a wp-content/mu-plugins/exploited.php file:
+      """
+      <?php
+      eval( base64_decode( $_POST ) );
+      """
+
+    When I run `wp doctor check file-eval`
+    Then STDOUT should be a table containing rows:
+      | name          | status    | message                                                      |
+      | file-eval     | error     | 1 'php' file failed check for 'eval\(.*base64_decode\(.*'.   |

--- a/inc/checks/class-file.php
+++ b/inc/checks/class-file.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace runcommand\Doctor\Checks;
+
+use SplFileInfo;
+
+/**
+ * Check files on the filesystem.
+ */
+class File extends Check {
+
+	/**
+	 * File checks are run as a group
+	 */
+	protected $when = false;
+
+	/**
+	 * Regex pattern to check.
+	 *
+	 * @var string
+	 */
+	protected $regex;
+
+	/**
+	 * File extension to check.
+	 *
+	 * Separate multiple file extensions with a '|'.
+	 *
+	 * @var string
+	 */
+	protected $extension = 'php';
+
+	/**
+	 * Any files matching the check.
+	 *
+	 * @var array
+	 */
+	protected $matches = array();
+
+	public function run() {
+
+		if ( isset( $this->regex ) ) {
+			if ( ! empty( $this->matches ) ) {
+				$this->status = 'error';
+				$count = count( $this->matches );
+				$message = $count === 1 ? "1 '{$this->extension}' file" : "{$count} '{$this->extension}' files";
+				$this->message = "{$message} failed check for '{$this->regex}'.";
+			} else {
+				$this->status = 'success';
+				$this->message = "All '{$this->extension}' files passed check for '{$this->regex}'.";
+			}
+		}
+
+	}
+
+	public function check_file( SplFileInfo $file ) {
+		if ( isset( $this->regex ) ) {
+			$contents = file_get_contents( $file->getPathname() );
+			if ( preg_match( '#' . $this->regex . '#i', $contents ) ) {
+				$this->matches[] = $file;
+			}
+		}
+	}
+
+	/**
+	 * Get the file extension for this check
+	 *
+	 * @return string
+	 */
+	public function get_extension() {
+		return $this->extension;
+	}
+
+}


### PR DESCRIPTION
Introduces a first pass at an abstraction for generic filesystem check.

Fixes https://github.com/runcommand/sparks/issues/6
See https://github.com/runcommand/sparks/issues/1
See https://github.com/runcommand/sparks/issues/7
