### PR TITLE
Add test case for checking use of sessions

### DIFF
--- a/features/check-file-contents.feature
+++ b/features/check-file-contents.feature
@@ -18,3 +18,38 @@ Feature: Check files in a WordPress install
     Then STDOUT should be a table containing rows:
       | name          | status    | message                                                      |
       | file-eval     | error     | 1 'php' file failed check for 'eval\(.*base64_decode\(.*'.   |
+
+  Scenario: Check for the use of sessions
+    Given a WP install
+    And a config.yml file:
+      """
+      file-sessions:
+        check: File_Contents
+        options:
+          regex: .*(session_start|\$_SESSION).*
+          only_wp_content: true
+      """
+
+    When I run `wp doctor check file-sessions --config=config.yml --format=json`
+    Then STDOUT should be JSON containing:
+      """
+      [{"name":"file-sessions","status":"success","message":"All 'php' files passed check for '.*(session_start|\\$_SESSION).*'."}]
+      """
+
+    Given a wp-content/mu-plugins/sessions1.php file:
+      """
+      <?php
+      session_start();
+      """
+    And a wp-content/mu-plugins/sessions2.php file:
+      """
+      <?php
+      echo '';
+      $_SESSION['foo'] = bar;
+      """
+
+    When I run `wp doctor check file-sessions --config=config.yml --format=json`
+    Then STDOUT should be JSON containing:
+      """
+      [{"name":"file-sessions","status":"error","message":"2 'php' files failed check for '.*(session_start|\\$_SESSION).*'."}]
+      """

--- a/inc/checks/class-file.php
+++ b/inc/checks/class-file.php
@@ -24,6 +24,13 @@ abstract class File extends Check {
 	protected $extension = 'php';
 
 	/**
+	 * Only check the wp-content directory.
+	 *
+	 * @var boolean
+	 */
+	protected $only_wp_content = false;
+
+	/**
 	 * Any files matching the check.
 	 *
 	 * @var array
@@ -41,12 +48,15 @@ abstract class File extends Check {
 	}
 
 	/**
-	 * Get the file extension for this check
+	 * Get the options for this check
 	 *
 	 * @return string
 	 */
-	public function get_extension() {
-		return $this->extension;
+	public function get_options() {
+		return array(
+			'extension'       => $this->extension,
+			'only_wp_content' => $this->only_wp_content,
+		);
 	}
 
 }

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -99,13 +99,19 @@ class Command {
 				try {
 					$directory = new RecursiveDirectoryIterator( ABSPATH, RecursiveDirectoryIterator::SKIP_DOTS );
 					$iterator = new RecursiveIteratorIterator( $directory, RecursiveIteratorIterator::CHILD_FIRST );
+					$wp_content_dir = defined( 'WP_CONTENT_DIR' ) ? WP_CONTENT_DIR : ABSPATH . 'wp-content';
 					foreach( $iterator as $file ) {
 						foreach( $file_checks as $name => $check ) {
-							$extension = $check->get_extension();
-							$extension = explode( '|', $extension );
-							if ( in_array( $file->getExtension(), $extension, true ) ) {
-								$check->check_file( $file );
+							$options = $check->get_options();
+							if ( ! empty( $options['only_wp_content'] )
+								&& 0 !== stripos( $file->getPath(), $wp_content_dir ) ) {
+								continue;
 							}
+							$extension = explode( '|', $options['extension'] );
+							if ( ! in_array( $file->getExtension(), $extension, true ) ) {
+								continue;
+							}
+							$check->check_file( $file );
 						}
 					}
 				} catch( Exception $e ) {


### PR DESCRIPTION
See https://github.com/runcommand/sparks/issues/7

Also introduces `$only_wp_content` option for file content checks

See https://github.com/runcommand/sparks/issues/1
