### PR TITLE
Support `File_Contents` check for a specific path

### DIFF
--- a/inc/checks/class-file.php
+++ b/inc/checks/class-file.php
@@ -24,6 +24,15 @@ abstract class File extends Check {
 	protected $extension = 'php';
 
 	/**
+	 * Check a specific file path.
+	 *
+	 * Value should be relative to ABSPATH (e.g. 'wp-content' or 'wp-config.php')
+	 *
+	 * @var string
+	 */
+	protected $path = '';
+
+	/**
 	 * Only check the wp-content directory.
 	 *
 	 * @var boolean
@@ -56,6 +65,7 @@ abstract class File extends Check {
 		return array(
 			'extension'       => $this->extension,
 			'only_wp_content' => $this->only_wp_content,
+			'path'            => $this->path,
 		);
 	}
 

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -107,6 +107,10 @@ class Command {
 								&& 0 !== stripos( $file->getPath(), $wp_content_dir ) ) {
 								continue;
 							}
+							if ( ! empty( $options['path'] )
+								&& 0 !== stripos( $file->getPathname(), ABSPATH . $options['path'] ) ) {
+								continue;
+							}
 							$extension = explode( '|', $options['extension'] );
 							if ( ! in_array( $file->getExtension(), $extension, true ) ) {
 								continue;


### PR DESCRIPTION
Includes a testcase to ensure `$_SERVER['SERVER_NAME']` isn't used to
populate `WP_HOME`

See https://github.com/runcommand/sparks/issues/1
Fixes https://github.com/runcommand/sparks/issues/7
