### PR TITLE
Add a file type checker for asserting `object-cache.php` isn't a symlink

### DIFF
--- a/features/check-file-type.feature
+++ b/features/check-file-type.feature
@@ -1,0 +1,61 @@
+Feature: Check the type of file
+
+  Scenario: Check that object-cache.php isn't a symlink
+    Given a WP install
+    And a config.yml file:
+      """
+      file-object-cache-symlink:
+        check: File_Type
+        options:
+          path: wp-content/object-cache.php
+          symlink: false
+      """
+
+    When I run `wp doctor check file-object-cache-symlink --config=config.yml`
+    Then STDOUT should be a table containing rows:
+      | name                      | status    | message                                                       |
+      | file-object-cache-symlink | success   | All 'php' files passed assertion that symlink is 'false'.     |
+
+    Given a wp-content/test.php file:
+      """
+      <?php
+      """
+    And I run `ln -s wp-content/test.php wp-content/object-cache.php`
+
+    When I run `wp doctor check file-object-cache-symlink --config=config.yml`
+    Then STDOUT should be a table containing rows:
+      | name                      | status    | message                                                       |
+      | file-object-cache-symlink | error     | 1 'php' file failed assertion that symlink is 'false'.        |
+
+
+  Scenario: Check that object-cache.php is a symlink
+    Given a WP install
+    And a config.yml file:
+      """
+      file-object-cache-symlink:
+        check: File_Type
+        options:
+          path: wp-content/object-cache.php
+          symlink: true
+      """
+    And a wp-content/object-cache.php file:
+      """
+      <?php
+      """
+
+    When I run `wp doctor check file-object-cache-symlink --config=config.yml`
+    Then STDOUT should be a table containing rows:
+      | name                      | status    | message                                                       |
+      | file-object-cache-symlink | error     | 1 'php' file failed assertion that symlink is 'true'.         |
+
+    Given a wp-content/test.php file:
+      """
+      <?php
+      """
+    And I run `rm wp-content/object-cache.php`
+    And I run `ln -s wp-content/test.php wp-content/object-cache.php`
+
+    When I run `wp doctor check file-object-cache-symlink --config=config.yml`
+    Then STDOUT should be a table containing rows:
+      | name                      | status    | message                                                       |
+      | file-object-cache-symlink | success   | All 'php' files passed assertion that symlink is 'true'.      |

--- a/inc/checks/class-file-type.php
+++ b/inc/checks/class-file-type.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace runcommand\Doctor\Checks;
+
+use SplFileInfo;
+
+/**
+ * Check the type of a file on the filesystem.
+ */
+class File_Type extends File {
+
+	/**
+	 * Assert the file type is or isn't a symlink.
+	 *
+	 * @var bool
+	 */
+	protected $symlink;
+
+	public function run() {
+
+		if ( isset( $this->symlink ) ) {
+			$symlink = $this->symlink ? 'true' : 'false';
+			if ( ! empty( $this->matches ) ) {
+				$this->status = 'error';
+				$count = count( $this->matches );
+				$message = $count === 1 ? "1 '{$this->extension}' file" : "{$count} '{$this->extension}' files";
+				$this->message = "{$message} failed assertion that symlink is '{$symlink}'.";
+			} else {
+				$this->status = 'success';
+				$this->message = "All '{$this->extension}' files passed assertion that symlink is '{$symlink}'.";
+			}
+		}
+
+	}
+
+	public function check_file( SplFileInfo $file ) {
+		if ( isset( $this->symlink ) ) {
+			if ( 'link' === $file->getType() && false === $this->symlink ) {
+				$this->matches[] = $file;
+			} else if ( 'link' !== $file->getType() && true === $this->symlink ) {
+				$this->matches[] = $file;
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/runcommand/sparks/issues/21
See https://github.com/runcommand/sparks/issues/1
