### PR TITLE
Capture any redirects emitted by WordPress

### DIFF
--- a/features/check.feature
+++ b/features/check.feature
@@ -70,3 +70,23 @@ Feature: Basic check usage
       | plugin-deactivated    |
       | plugin-update         |
       | theme-update          |
+
+  Scenario: Discard redirects emitted by WordPress
+    Given a WP install
+    And a wp-content/mu-plugins/redirect.php file:
+      """
+      <?php
+      add_action( 'template_redirect', function(){
+        wp_redirect( 'http://google.com' );
+        exit;
+      });
+      """
+
+    When I run `wp doctor check autoload-options-size --fields=name,status`
+    Then STDERR should contain:
+      """
+      Warning: Incomplete check execution. Some code is trying to do a URL redirect. Backtrace:
+      """
+    And STDOUT should be a table containing rows:
+      | name                   | status             |
+      | autoload-options-size  | success            |

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -144,7 +144,11 @@ class Command {
 			});
 		}
 
-		$this->load_wordpress_with_template();
+		try {
+			$this->load_wordpress_with_template();
+		} catch( Exception $e ) {
+			WP_CLI::warning( $e->getMessage() );
+		}
 
 		$results = array();
 		foreach( $completed as $name => $check ) {
@@ -255,6 +259,13 @@ class Command {
 	 */
 	private function load_wordpress_with_template() {
 		global $wp_query;
+
+		WP_CLI::add_wp_hook( 'wp_redirect', function( $to ){
+			ob_start();
+			debug_print_backtrace();
+			$message = ob_get_clean();
+			throw new Exception( "Incomplete check execution. Some code is trying to do a URL redirect. Backtrace:" . PHP_EOL . $message );
+		}, 1 );
 
 		WP_CLI::get_runner()->load_wordpress();
 

--- a/inc/class-exception.php
+++ b/inc/class-exception.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace runcommand\Doctor;
+
+class Exception extends \Exception {}


### PR DESCRIPTION
This is more helpful behavior than WP-CLI's default redirect error
handler.
