### PR TITLE
Error when check is missing `class` or `check`

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -51,6 +51,23 @@ Feature: Configure the Doctor
       Error: Check name 'check space' is invalid. Verify check registration.
       """
 
+  Scenario: Error when a check is missing its 'check' or 'class'
+    Given an empty directory
+    And a config.yml file:
+      """
+      constant-custom:
+        constant: Constant_Definition
+        options:
+          constant: CUSTOM
+          defined: true
+      """
+
+    When I try `wp doctor list --config=config.yml`
+    Then STDERR should be:
+      """
+      Error: Check 'constant-custom' is missing 'class' or 'check'. Verify check registration.
+      """
+
   Scenario: Support inheriting another config file
     Given an empty directory
     And a first-config.yml file:

--- a/inc/class-checks.php
+++ b/inc/class-checks.php
@@ -35,9 +35,11 @@ class Checks {
 			self::register_config( $inherited );
 		}
 
+		unset( $check_data['_'] );
+
 		foreach( $check_data as $check_name => $check_args ) {
 			if ( empty( $check_args['class'] ) && empty( $check_args['check'] ) ) {
-				continue;
+				WP_CLI::error( "Check '{$check_name}' is missing 'class' or 'check'. Verify check registration." );
 			}
 
 			$class = ! empty( $check_args['check'] ) ? 'runcommand\Doctor\Checks\\' . $check_args['check'] : $check_args['class'];


### PR DESCRIPTION
These are required attributes of check registration. Erroring helps the
user figure out why the check is missing.
