### PR TITLE
Support requiring a custom check from `config.yml`

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -209,3 +209,18 @@ Feature: Configure the Doctor
     Then STDOUT should be a table containing rows:
       | name                         | status       | message              |
       | plugin-akismet-valid-api-key | error        | API key is missing.  |
+
+  Scenario: 'require' attribute fails successfully when the file doesn't exist
+    Given a WP install
+    And a config.yml file:
+      """
+      plugin-akismet-valid-api-key:
+        class: Akismet_Valid_API_Key
+        require: akismet-valid-api-key.php
+      """
+
+    When I try `wp doctor check --all --config=config.yml`
+    Then STDERR should be:
+      """
+      Error: Required file 'akismet-valid-api-key.php' doesn't exist (from 'plugin-akismet-valid-api-key').
+      """

--- a/inc/class-checks.php
+++ b/inc/class-checks.php
@@ -48,7 +48,12 @@ class Checks {
 		$skipped_checks = isset( self::get_instance()->skipped_checks[ $file ] ) ? self::get_instance()->skipped_checks[ $file ] : array();
 		foreach( $check_data as $check_name => $check_args ) {
 			if ( ! empty( $check_args['require'] ) ) {
-				require_once self::absolutize( $check_args['require'], dirname( $file ) );
+				$required_file = self::absolutize( $check_args['require'], dirname( $file ) );
+				if ( ! file_exists( $required_file ) ) {
+					$required_file = basename( $required_file );
+					WP_CLI::error( "Required file '{$required_file}' doesn't exist (from '{$check_name}')." );
+				}
+				require_once $required_file;
 			}
 
 			if ( empty( $check_args['class'] ) && empty( $check_args['check'] ) ) {


### PR DESCRIPTION
This is easier than using `--require` separately