### PR TITLE
Warn instead of error when `RecursiveDirectoryIterator` excepts

### DIFF
--- a/features/check-core-update.feature
+++ b/features/check-core-update.feature
@@ -28,7 +28,7 @@ Feature: Check whether WordPress is up to date
 
   Scenario: WordPress has a new major version but no new minor version
     Given a WP install
-    And I run `wp core download --version=4.4.7 --force`
+    And I run `wp core download --version=4.4.8 --force`
     And I run `wp theme activate twentyfifteen`
 
     When I run `wp doctor check core-update`

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -134,7 +134,7 @@ class Command {
 						}
 					}
 				} catch( Exception $e ) {
-					WP_CLI::error( $e->getMessage() );
+					WP_CLI::warning( $e->getMessage() );
 				}
 				foreach( $file_checks as $name => $check ) {
 					$check->run();


### PR DESCRIPTION
Doing so permits doctor to continue operating, when fixing the problem
may be out of immediate scope.

Fixes #104