### PR TITLE
Local testing with Docker

### DIFF
--- a/Dockerfile_for_testing
+++ b/Dockerfile_for_testing
@@ -1,0 +1,34 @@
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    mysql-server \
+    php7.0 \
+	php7.0-curl \
+    php7.0-cli \
+    php7.0-xml \
+    php7.0-mysql \
+    curl \
+    git \
+    zip \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer -o composer_installer && \
+    php composer_installer --install-dir=/usr/local/bin --filename=composer && \
+    rm composer_installer
+
+RUN mkdir /repo
+COPY composer.json /repo
+
+WORKDIR /repo
+RUN composer require wp-cli/wp-cli:dev-master && composer install
+ENV PATH="/repo/vendor/bin:${PATH}"
+
+COPY . /repo
+
+RUN service mysql start && bash bin/install-package-tests.sh
+
+RUN useradd -u 9000 app
+CMD service mysql start && su - app -c "export PATH=/repo/vendor/bin:${PATH} && cd /repo && bash bin/test.sh"

--- a/bin/test-in-docker.sh
+++ b/bin/test-in-docker.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+docker build -t doctor-command-test -f Dockerfile_for_testing .
+docker run -it doctor-command-test


### PR DESCRIPTION
I don't know if there is any need or interest in this, but at least for me, this would have been awesome to have right off the bat as a first-time contributor. I don't keep mysql and some of the required tools installed directly on my machine anymore, so getting the tests to run locally was a big pain point. After pushing a ton of dumb commits to Travis to test things, I ended up throwing together a docker container. This could basically give anybody a one-line command to run tests without having to set anything up, other than Docker (`bash bin/test-in-docker.sh`). It could use a little cleanup (I think you could also combine it into a 1 file addition), but you get the idea.

I'd be happy to spend a little more time on this if it's something that would be useful for the project, otherwise I'll just use it in our fork...