### PR TITLE
Update required `wp-cli/wp-cli` version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "wp-cli/entity-command": "^2",
         "wp-cli/extension-command": "^2",
         "wp-cli/language-command": "^2",
-        "wp-cli/wp-cli": "^2.1.0"
+        "wp-cli/wp-cli": "^2.1"
     },
     "require-dev": {
         "wp-cli/wp-cli-tests": "^2.0.7"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "wp-cli/entity-command": "^2",
         "wp-cli/extension-command": "^2",
         "wp-cli/language-command": "^2",
-        "wp-cli/wp-cli": "dev-master"
+        "wp-cli/wp-cli": "^2.1.0"
     },
     "require-dev": {
         "wp-cli/wp-cli-tests": "^2.0.7"


### PR DESCRIPTION
Require wp-cli 2.10 instead of dev-master.