### PR TITLE
Add CircleCI 2.1 config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Prep for testing with PHP v5.4."
+          name: "Prep for testing with PHP v5.4. "
           command: |
             apt-get update && sudo apt-get install -y mysql-client
             docker-php-ext-install mysqli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ workflows:
       - tests:
           php: "5.6"
           wpVersion: "trunk"
+      - test54
 
 jobs:
   tests:
@@ -41,6 +42,51 @@ jobs:
             sudo docker-php-ext-install mysqli
             echo 'export PATH="$CIRCLE_WORKING_DIRECTORY/vendor/bin:$PATH"' >> $BASH_ENV
             echo -e "memory_limit = 2048M" | sudo tee /usr/local/etc/php/php.ini > /dev/null
+      - restore_cache:
+          keys:
+            - composer-v1-{{ checksum "composer.json" }}
+      - run:
+          name: "Setup with Composer"
+          command: |
+            composer validate
+            composer install
+            composer prepare-tests
+            mysql -uroot -e "UPDATE mysql.user SET host = '%' WHERE user = 'wp_cli_test'"
+            mysql -uroot -e "UPDATE mysql.db SET host = '%' WHERE user = 'wp_cli_test'"
+            mysql -uroot -e "FLUSH PRIVILEGES"
+      - save_cache:
+          key: composer-v1-{{ checksum "composer.json" }}
+          paths:
+            - vendor
+      - run:
+          name: "Run Tests"
+          command: |
+            composer phpunit
+            composer behat || composer behat-rerun
+
+  test54:
+    parameters:
+      wpVersion:
+        type: string
+        default: "latest"
+    docker:
+      - image: php:5.4
+      - image: circleci/mysql:5.6
+    environment:
+      MYSQL_HOST: 127.0.0.1
+      MYSQL_USER: root
+      MYSQL_ALLOW_EMPTY_PASSWORD: true
+      WP_CLI_BIN_DIR: "/home/circleci/project/vendor/bin"
+      WP_VERSION: << parameters.wpVersion >>
+    steps:
+      - checkout
+      - run:
+          name: "Prep for testing with PHP v5.4."
+          command: |
+            apt-get update && sudo apt-get install -y mysql-client
+            docker-php-ext-install mysqli
+            echo 'export PATH="$CIRCLE_WORKING_DIRECTORY/vendor/bin:$PATH"' >> $BASH_ENV
+            echo -e "memory_limit = 2048M" | tee /usr/local/etc/php/php.ini > /dev/null
       - restore_cache:
           keys:
             - composer-v1-{{ checksum "composer.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,63 @@
+version: 2.1
+
+workflows:
+  main:
+    jobs:
+      - tests:
+          php: "7.2"
+      - tests:
+          php: "7.1"
+      - tests:
+          php: "7.0"
+      - tests:
+          php: "5.6"
+      - tests:
+          php: "5.6"
+          wpVersion: "trunk"
+
+jobs:
+  tests:
+    parameters:
+      php:
+        type: string
+      wpVersion:
+        type: string
+        default: "latest"
+    docker:
+      - image: circleci/php:<< parameters.php >>-browsers
+      - image: circleci/mysql:5.6
+    environment:
+      MYSQL_HOST: 127.0.0.1
+      MYSQL_USER: root
+      MYSQL_ALLOW_EMPTY_PASSWORD: true
+      WP_CLI_BIN_DIR: "/home/circleci/project/vendor/bin"
+      WP_VERSION: << parameters.wpVersion >>
+    steps:
+      - checkout
+      - run:
+          name: "Prep for testing with PHP v<< parameters.php >>."
+          command: |
+            sudo apt-get update && sudo apt-get install -y mysql-client
+            sudo docker-php-ext-install mysqli
+            echo 'export PATH="$CIRCLE_WORKING_DIRECTORY/vendor/bin:$PATH"' >> $BASH_ENV
+            echo -e "memory_limit = 2048M" | sudo tee /usr/local/etc/php/php.ini > /dev/null
+      - restore_cache:
+          keys:
+            - composer-v1-{{ checksum "composer.json" }}
+      - run:
+          name: "Setup with Composer"
+          command: |
+            composer validate
+            composer install
+            composer prepare-tests
+            composer phpunit
+            mysql -uroot -e "UPDATE mysql.user SET host = '%' WHERE user = 'wp_cli_test'"
+            mysql -uroot -e "UPDATE mysql.db SET host = '%' WHERE user = 'wp_cli_test'"
+            mysql -uroot -e "FLUSH PRIVILEGES"
+      - save_cache:
+          key: composer-v1-{{ checksum "composer.json" }}
+          paths:
+            - vendor
+      - run:
+          name: "Run Tests"
+          command: composer behat || composer behat-rerun

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ jobs:
             composer validate
             composer install
             composer prepare-tests
-            composer phpunit
             mysql -uroot -e "UPDATE mysql.user SET host = '%' WHERE user = 'wp_cli_test'"
             mysql -uroot -e "UPDATE mysql.db SET host = '%' WHERE user = 'wp_cli_test'"
             mysql -uroot -e "FLUSH PRIVILEGES"
@@ -60,4 +59,6 @@ jobs:
             - vendor
       - run:
           name: "Run Tests"
-          command: composer behat || composer behat-rerun
+          command: |
+            composer phpunit
+            composer behat || composer behat-rerun


### PR DESCRIPTION
Hey,

Here is a first stab at a CircleCI config to test the `doctor-command` repo.

This is using CircleCI v2.1 config syntax and designed to be as close as possible to what's currently happening in the Travis CI builds.

Some immediate differences differences:

- on the free plan, only 4 containers max will run in parallel
- There isn't a PHP v5.4 job. CircleCI (because of upstream Docker Library/PHP) don't have recently built PHP 5.4 images. Honestly, PHP 5.4 went EOL over 3 years ago so this shouldn't be a problem.
- I didn't implement the "sniff" job/commands.

Please let me know if there are any questions to what I did, my approach, or how something works.

Also, I was told that the CI process for the command repos seem to more or less be the same. If that's the case, once this config is completed, optimized, and vetted, it could be turned into a [CircleCI Orb](https://circleci.com/orbs/). This will allow the config to be updated in one location (the orb repo) and can be used in all of the command repos being built on CircleCI. Implementing DRY config.