### PR TITLE
Move PHP 5.4 tests from `WP_VERSION` `latest` to `5.1`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
     parameters:
       wpVersion:
         type: string
-        default: "latest"
+        default: "5.1"
     docker:
       - image: php:5.4
       - image: circleci/mysql:5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,4 +67,4 @@ jobs:
       env: WP_VERSION=trunk
     - stage: test
       php: 5.4
-      env: WP_VERSION=latest
+      env: WP_VERSION=5.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,4 +67,4 @@ jobs:
       env: WP_VERSION=trunk
     - stage: test
       php: 5.4
-      env: WP_VERSION=5.1
+      env: WP_VERSION=5.1.1


### PR DESCRIPTION
Related wp-cli/wp-cli#5127