### PR TITLE
Use `cli` image instead of `browsers`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,12 +84,9 @@ jobs:
           name: "Prep for testing with PHP v5.4."
           command: |
             apt-get update && sudo apt-get install -y mysql-client
-            docker-php-ext-install mysqli
+            docker-php-ext-install mysqli zip
             echo 'export PATH="$CIRCLE_WORKING_DIRECTORY/vendor/bin:$PATH"' >> $BASH_ENV
             echo -e "memory_limit = 2048M" | tee /usr/local/etc/php/php.ini > /dev/null
-      - run:
-          name: "Install PHP zip extension"
-          command: sudo apt-get install -y php-zip
       - run:
           name: "Install git"
           command: sudo apt-get install -y git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
     parameters:
       wpVersion:
         type: string
-        default: "latest"
+        default: "5.1.1"
     docker:
       - image: php:5.4
       - image: circleci/mysql:5.6
@@ -87,6 +87,9 @@ jobs:
             docker-php-ext-install mysqli
             echo 'export PATH="$CIRCLE_WORKING_DIRECTORY/vendor/bin:$PATH"' >> $BASH_ENV
             echo -e "memory_limit = 2048M" | tee /usr/local/etc/php/php.ini > /dev/null
+      - run:
+          name: "Install git"
+          command: sudo apt-get install -y git
       - run:
           name: "Install Composer"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,9 @@ jobs:
             echo 'export PATH="$CIRCLE_WORKING_DIRECTORY/vendor/bin:$PATH"' >> $BASH_ENV
             echo -e "memory_limit = 2048M" | tee /usr/local/etc/php/php.ini > /dev/null
       - run:
+          name: "Install PHP zip extension"
+          command: sudo apt-get install -y php-zip
+      - run:
           name: "Install git"
           command: sudo apt-get install -y git
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,12 +81,19 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Prep for testing with PHP v5.4. "
+          name: "Prep for testing with PHP v5.4."
           command: |
             apt-get update && sudo apt-get install -y mysql-client
             docker-php-ext-install mysqli
             echo 'export PATH="$CIRCLE_WORKING_DIRECTORY/vendor/bin:$PATH"' >> $BASH_ENV
             echo -e "memory_limit = 2048M" | tee /usr/local/etc/php/php.ini > /dev/null
+      - run:
+          name: "Install Composer"
+          command: |
+            php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/master/web/installer', 'composer-setup.php');" && \
+            php composer-setup.php && \
+            php -r "unlink('composer-setup.php');" && \
+            mv composer.phar /usr/local/bin/composer
       - restore_cache:
           keys:
             - composer-v1-{{ checksum "composer.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
         type: string
         default: "5.1.1"
     docker:
-      - image: php:5.4
+      - image: devilbox/php-fpm:5.4-work
       - image: circleci/mysql:5.6
     environment:
       MYSQL_HOST: 127.0.0.1
@@ -87,16 +87,6 @@ jobs:
             docker-php-ext-install mysqli zip
             echo 'export PATH="$CIRCLE_WORKING_DIRECTORY/vendor/bin:$PATH"' >> $BASH_ENV
             echo -e "memory_limit = 2048M" | tee /usr/local/etc/php/php.ini > /dev/null
-      - run:
-          name: "Install git"
-          command: sudo apt-get install -y git
-      - run:
-          name: "Install Composer"
-          command: |
-            php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/master/web/installer', 'composer-setup.php');" && \
-            php composer-setup.php && \
-            php -r "unlink('composer-setup.php');" && \
-            mv composer.phar /usr/local/bin/composer &&
             composer self-update
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
         type: string
         default: "latest"
     docker:
-      - image: circleci/php:<< parameters.php >>-browsers
+      - image: circleci/php:<< parameters.php >>-cli
       - image: circleci/mysql:5.6
     environment:
       MYSQL_HOST: 127.0.0.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,8 @@ jobs:
             php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/master/web/installer', 'composer-setup.php');" && \
             php composer-setup.php && \
             php -r "unlink('composer-setup.php');" && \
-            mv composer.phar /usr/local/bin/composer
+            mv composer.phar /usr/local/bin/composer &&
+            composer self-update
       - restore_cache:
           keys:
             - composer-v1-{{ checksum "composer.json" }}


### PR DESCRIPTION
The `browsers` image does not seem to include Composer by default.

<!--

Thanks for submitting a pull request!

Here's an overview to our process:

1. One of the project committers will soon provide a code review.
2. You are expected to address the code review comments in a timely manner.
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->