### PR TITLE
Fix divide-by-zero warning in plugin checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,10 @@
             "php": "5.6"
         },
         "process-timeout": 7200,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "branch-alias": {

--- a/features/check-plugin-active-count.feature
+++ b/features/check-plugin-active-count.feature
@@ -33,3 +33,12 @@ Feature: Check whether a high number of plugins are activated
     Then STDOUT should be a table containing rows:
       | name                | status  | message                                             |
       | plugin-active-count | warning | Number of active plugins (4) exceeds threshold (3). |
+
+  Scenario: Include network-enabled plugins in active plugin count
+    Given a WP multisite installation
+    And I run `wp plugin activate --network --all`
+
+    When I run `wp doctor check plugin-active-count`
+    Then STDOUT should be a table containing rows:
+      | name                | status  | message                                                   |
+      | plugin-active-count | success | Number of active plugins (2) is less than threshold (80). |

--- a/features/check-plugin-deactivated.feature
+++ b/features/check-plugin-deactivated.feature
@@ -42,3 +42,21 @@ Feature: Check whether a high percentage of plugins are deactivated
     Then STDOUT should be a table containing rows:
       | name               | status  | message                                          |
       | plugin-deactivated | warning | Greater than 60 percent of plugins are deactivated. |
+
+  Scenario: Gracefully handle no plugins installed
+    Given a WP install
+    And I run `wp plugin uninstall --all`
+
+    When I run `wp doctor check plugin-deactivated`
+    Then STDOUT should be a table containing rows:
+      | name               | status  | message                                          |
+      | plugin-deactivated | success | Less than 40 percent of plugins are deactivated. |
+
+  Scenario: Gracefully handle only network-enabled plugins installed and activated
+    Given a WP multisite installation
+    And I run `wp plugin activate --network --all`
+
+    When I run `wp doctor check plugin-deactivated`
+    Then STDOUT should be a table containing rows:
+      | name               | status  | message                                          |
+      | plugin-deactivated | success | Less than 40 percent of plugins are deactivated. |

--- a/inc/checks/class-plugin-active-count.php
+++ b/inc/checks/class-plugin-active-count.php
@@ -21,7 +21,7 @@ class Plugin_Active_Count extends Plugin {
 
 		$active = 0;
 		foreach ( self::get_plugins() as $plugin ) {
-			if ( 'active' === $plugin['status'] ) {
+			if ( 'active' === $plugin['status'] || 'active-network' === $plugin['status'] ) {
 				$active++;
 			}
 		}

--- a/inc/checks/class-plugin-deactivated.php
+++ b/inc/checks/class-plugin-deactivated.php
@@ -30,7 +30,7 @@ class Plugin_Deactivated extends Plugin {
 		}
 
 		$threshold = (int) $this->threshold_percentage;
-		if ( ( $inactive / ( $inactive + $active ) ) > ( $threshold / 100 ) ) {
+		if ( $inactive + $active > 0 && ( $inactive / ( $inactive + $active ) ) > ( $threshold / 100 ) ) {
 			$this->set_status( 'warning' );
 			$this->set_message( "Greater than {$threshold} percent of plugins are deactivated." );
 		} else {

--- a/inc/checks/class-plugin-deactivated.php
+++ b/inc/checks/class-plugin-deactivated.php
@@ -22,7 +22,7 @@ class Plugin_Deactivated extends Plugin {
 		$active   = 0;
 		$inactive = 0;
 		foreach ( self::get_plugins() as $plugin ) {
-			if ( 'active' === $plugin['status'] ) {
+			if ( 'active' === $plugin['status'] || 'active-network' === $plugin['status'] ) {
 				$active++;
 			} elseif ( 'inactive' === $plugin['status'] ) {
 				$inactive++;


### PR DESCRIPTION
Aloha, in WordPress environments with no plugins installed, or multisite environments with only network-activated plugins, the `plugin-deactivated` check will throw a divide-by-zero warning:

```
$ wp doctor check plugin-deactivated
PHP Warning:  Division by zero in /home/ubuntu/.wp-cli/packages/vendor/wp-cli/doctor-command/inc/checks/class-plugin-deactivated.php on line 33
+--------------------+---------+--------------------------------------------------+
| name               | status  | message                                          |
+--------------------+---------+--------------------------------------------------+
| plugin-deactivated | success | Less than 40 percent of plugins are deactivated. |
+--------------------+---------+--------------------------------------------------+
```

Example plugin list:
```
$ wp plugin list
+----------------------------+----------------+-----------+---------+
| name                       | status         | update    | version |
+----------------------------+----------------+-----------+---------+
| advanced-custom-fields-pro | active-network | none      | 5.12.3  |
| classic-editor             | active-network | none      | 1.6.2   |
+----------------------------+----------------+-----------+---------+
```

This pull request explicitly checks that there are more than 0 active/inactive plugins, and also adds the `active-network` status to the count of activated plugins in the `plugin-active-count` and `plugin-deactivated` checks. See the following for a list of valid statuses:
https://developer.wordpress.org/cli/commands/plugin/list/

Thanks!
