### PR TITLE
Correct docblock in class-cache-flush.php

### DIFF
--- a/inc/checks/class-cache-flush.php
+++ b/inc/checks/class-cache-flush.php
@@ -7,7 +7,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
 /**
- * Detects the number of occurrences of the `wp_cache_flush()` function.
+ * Detects any use of the `wp_cache_flush()` function.
  */
 class Cache_Flush extends File_Contents {
 


### PR DESCRIPTION
checks use of the function, not number of occurrences

Fixes https://github.com/wp-cli/doctor-command/issues/173