### PR TITLE
cache-flush check: Return early if a match is found

### DIFF
--- a/inc/checks/class-cache-flush.php
+++ b/inc/checks/class-cache-flush.php
@@ -23,6 +23,10 @@ class Cache_Flush extends File_Contents {
 
 		foreach ( $iterator as $file ) {
 			$this->check_file( $file );
+			if ( ! empty( $this->_matches ) ) {
+				// we are currently interested whether there's a use of wp_cache_flush() or not.
+				break;
+			}
 		}
 
 		if ( empty( $this->_matches ) ) {


### PR DESCRIPTION
We currently scan all the PHP files in the target WP content dir looking for `wp_cache_flush()` uses, however we are not currently using the results in a meaninful way so we can just probably return early if the current check found a match.

If there are plans to list the matched files, we can probably attempt to use some more performan alternatives (grep if available for example) which should be likely faster than a PHP based implementation.

See https://github.com/wp-cli/doctor-command/issues/178

<!--

Thanks for submitting a pull request!

Here's an overview to our process:

1. One of the project committers will soon provide a code review.
2. You are expected to address the code review comments in a timely manner.
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
