### PR TITLE
Add list of files to report of 'wp doctor check cache-flush' command

### DIFF
--- a/features/check-cache-flush.feature
+++ b/features/check-cache-flush.feature
@@ -11,4 +11,4 @@ Feature: Check if wp_cache_flush() function is used inside wp-content directory
     When I run `wp doctor check cache-flush`
     Then STDOUT should be a table containing rows:
       | name        | status  | message                           |
-      | cache-flush | warning | Use of wp_cache_flush() detected. |
+      | cache-flush | warning | Use of wp_cache_flush() detected in mu-plugins/plugin.php |

--- a/features/check-cache-flush.feature
+++ b/features/check-cache-flush.feature
@@ -9,6 +9,19 @@ Feature: Check if wp_cache_flush() function is used inside wp-content directory
       """
 
     When I run `wp doctor check cache-flush`
-    Then STDOUT should be a table containing rows:
-      | name        | status  | message                           |
-      | cache-flush | warning | Use of wp_cache_flush() detected in mu-plugins/plugin.php |
+    Then STDOUT should contain:
+      """
+      cache-flush
+      """
+    And STDOUT should contain:
+      """
+      warning
+      """
+    And STDOUT should contain:
+      """
+      Use of wp_cache_flush() detected
+      """
+    And STDOUT should contain:
+      """
+      mu-plugins/plugin.php
+      """

--- a/inc/checks/class-cache-flush.php
+++ b/inc/checks/class-cache-flush.php
@@ -23,10 +23,6 @@ class Cache_Flush extends File_Contents {
 
 		foreach ( $iterator as $file ) {
 			$this->check_file( $file );
-			if ( ! empty( $this->_matches ) ) {
-				// we are currently interested whether there's a use of wp_cache_flush() or not.
-				break;
-			}
 		}
 
 		if ( empty( $this->_matches ) ) {
@@ -36,6 +32,6 @@ class Cache_Flush extends File_Contents {
 		}
 
 		$this->set_status( 'warning' );
-		$this->set_message( 'Use of wp_cache_flush() detected.' );
+		$this->set_message( 'Use of wp_cache_flush() detected in ' . implode( ', ', $this->_matches )  );
 	}
 }

--- a/inc/checks/class-cache-flush.php
+++ b/inc/checks/class-cache-flush.php
@@ -31,7 +31,15 @@ class Cache_Flush extends File_Contents {
 			return;
 		}
 
+		// Show relative paths in output.
+		$relative_paths = array_map(
+			function ( $file ) use ( $wp_content_dir ) {
+				return str_replace( $wp_content_dir . '/', '', $file );
+			},
+			$this->_matches
+		);
+
 		$this->set_status( 'warning' );
-		$this->set_message( 'Use of wp_cache_flush() detected in ' . implode( ', ', $this->_matches ) );
+		$this->set_message( 'Use of wp_cache_flush() detected in ' . implode( ', ', $relative_paths ) );
 	}
 }

--- a/inc/checks/class-cache-flush.php
+++ b/inc/checks/class-cache-flush.php
@@ -7,7 +7,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
 /**
- * Detects any use of the `wp_cache_flush()` function.
+ * Detects and reports the path of files for occurrences of the `wp_cache_flush()` function.
  */
 class Cache_Flush extends File_Contents {
 

--- a/inc/checks/class-cache-flush.php
+++ b/inc/checks/class-cache-flush.php
@@ -32,6 +32,6 @@ class Cache_Flush extends File_Contents {
 		}
 
 		$this->set_status( 'warning' );
-		$this->set_message( 'Use of wp_cache_flush() detected in ' . implode( ', ', $this->_matches )  );
+		$this->set_message( 'Use of wp_cache_flush() detected in ' . implode( ', ', $this->_matches ) );
 	}
 }


### PR DESCRIPTION
Fixes #184

This PR adds enhancement for the `wp doctor check cache-flush` command as mentioned in issue #184

The output will show the list of files where `wp_cache_flush()` is used.