### PR TITLE
Require `wp-cli/wp-cli` v2.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "wp-cli/entity-command": "^2",
         "wp-cli/extension-command": "^2",
         "wp-cli/language-command": "^2",
-        "wp-cli/wp-cli": "^2.1"
+        "wp-cli/wp-cli": "^2.12"
     },
     "require-dev": {
         "wp-cli/wp-cli-tests": "^4"


### PR DESCRIPTION
Addresses PHP 8.4 deprecation warnings

<!--

Thanks for submitting a pull request!

Here's an overview to our process:

1. One of the project committers will soon provide a code review.
2. You are expected to address the code review comments in a timely manner.
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
