### PR TITLE
Add transients size check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "wp-cli/checksum-command": "^2",
         "wp-cli/core-command": "^2",
         "wp-cli/cron-command": "^2",
-        "wp-cli/entity-command": "^2",
+        "wp-cli/entity-command": "^2.8.12",
         "wp-cli/extension-command": "^2",
         "wp-cli/language-command": "^2",
         "wp-cli/wp-cli": "^2.13"

--- a/doctor.yml
+++ b/doctor.yml
@@ -1,6 +1,8 @@
 # Default check configuration for `wp doctor`
 autoload-options-size:
   check: Autoload_Options_Size
+transients-size:
+  check: Transients_Size
 constant-savequeries-falsy:
   check: Constant_Definition
   options:

--- a/features/check-autoload-options-size.feature
+++ b/features/check-autoload-options-size.feature
@@ -19,7 +19,7 @@ Feature: Check the size of autoloaded options
     When I run `wp doctor check autoload-options-size --fields=message`
     Then STDOUT should contain:
       """
-      is less than threshold (900kb)
+      does not exceed threshold (900kb)
       """
 
   @less-than-wp-6.5
@@ -59,5 +59,5 @@ Feature: Check the size of autoloaded options
     When I run `wp doctor check autoload-options-size --fields=message --config=custom.yml`
     Then STDOUT should contain:
       """
-      is less than threshold (800kb)
+      does not exceed threshold (800kb)
       """

--- a/features/check-transients-size.feature
+++ b/features/check-transients-size.feature
@@ -79,3 +79,35 @@ Feature: Check the size of autoloaded transients
       """
       is less than threshold (800kb)
       """
+
+  Scenario: Zero threshold is formatted safely
+    Given a WP install
+    And a custom.yml file:
+      """
+      transients-size:
+        class: WP_CLI\Doctor\Check\Transients_Size
+        options:
+          threshold_kb: 0
+      """
+
+    When I run `wp doctor check transients-size --fields=message --config=custom.yml`
+    Then STDOUT should contain:
+      """
+      threshold (0)
+      """
+
+  Scenario: Very large thresholds are formatted safely
+    Given a WP install
+    And a custom.yml file:
+      """
+      transients-size:
+        class: WP_CLI\Doctor\Check\Transients_Size
+        options:
+          threshold_kb: 1099511627776
+      """
+
+    When I run `wp doctor check transients-size --fields=message --config=custom.yml`
+    Then STDOUT should contain:
+      """
+      is less than threshold (1024t)
+      """

--- a/features/check-transients-size.feature
+++ b/features/check-transients-size.feature
@@ -29,7 +29,7 @@ Feature: Check the size of autoloaded transients
       <?php
       $value = str_repeat( '9', 15000 );
       for ( $i = 0; $i < 75; $i++ ) {
-        set_transient( 'doctor_big_' . $i, $value );
+        add_option( '_transient_doctor_big_' . $i, $value, '', true );
       }
       """
     And I run `wp eval-file create-large-transients.php`
@@ -53,7 +53,8 @@ Feature: Check the size of autoloaded transients
       $value = str_repeat( '9', 15000 );
       for ( $i = 0; $i < 75; $i++ ) {
         update_option( 'doctor_big_option_' . $i, $value, true );
-        set_transient( 'doctor_expiring_big_' . $i, $value, HOUR_IN_SECONDS );
+        add_option( '_transient_doctor_expiring_big_' . $i, $value, '', false );
+        add_option( '_transient_timeout_doctor_expiring_big_' . $i, time() + HOUR_IN_SECONDS, '', false );
       }
       """
     And I run `wp eval-file create-large-nonmatching-data.php`

--- a/features/check-transients-size.feature
+++ b/features/check-transients-size.feature
@@ -1,0 +1,80 @@
+Feature: Check the size of autoloaded transients
+
+  Scenario: Verify check description
+    Given an empty directory
+
+    When I run `wp doctor list --fields=name,description`
+    Then STDOUT should be a table containing rows:
+      | name            | description                                                                      |
+      | transients-size | Warns when autoloaded transients size exceeds threshold of 900 kb.               |
+
+  Scenario: Autoloaded transients are less than 900 kb
+    Given a WP install
+
+    When I run `wp doctor check transients-size --fields=name,status`
+    Then STDOUT should be a table containing rows:
+      | name            | status  |
+      | transients-size | success |
+
+    When I run `wp doctor check transients-size --fields=message`
+    Then STDOUT should contain:
+      """
+      is less than threshold (900kb)
+      """
+
+  Scenario: Autoloaded transients are greater than 900 kb
+    Given a WP install
+    And a create-large-transients.php file:
+      """
+      <?php
+      $value = str_repeat( '9', 15000 );
+      for ( $i = 0; $i < 75; $i++ ) {
+        set_transient( 'doctor_big_' . $i, $value );
+      }
+      """
+    And I run `wp eval-file create-large-transients.php`
+
+    When I run `wp doctor check transients-size --fields=name,status`
+    Then STDOUT should be a table containing rows:
+      | name            | status  |
+      | transients-size | warning |
+
+    When I run `wp doctor check transients-size --fields=message`
+    Then STDOUT should contain:
+      """
+      exceeds threshold (900kb)
+      """
+
+  Scenario: Autoloaded options and expiring transients are ignored
+    Given a WP install
+    And a create-large-nonmatching-data.php file:
+      """
+      <?php
+      $value = str_repeat( '9', 15000 );
+      for ( $i = 0; $i < 75; $i++ ) {
+        update_option( 'doctor_big_option_' . $i, $value, true );
+        set_transient( 'doctor_expiring_big_' . $i, $value, HOUR_IN_SECONDS );
+      }
+      """
+    And I run `wp eval-file create-large-nonmatching-data.php`
+
+    When I run `wp doctor check transients-size --fields=name,status`
+    Then STDOUT should be a table containing rows:
+      | name            | status  |
+      | transients-size | success |
+
+  Scenario: Custom configuration
+    Given a WP install
+    And a custom.yml file:
+      """
+      transients-size:
+        class: WP_CLI\Doctor\Check\Transients_Size
+        options:
+          threshold_kb: 800
+      """
+
+    When I run `wp doctor check transients-size --fields=message --config=custom.yml`
+    Then STDOUT should contain:
+      """
+      is less than threshold (800kb)
+      """

--- a/features/check-transients-size.feature
+++ b/features/check-transients-size.feature
@@ -19,7 +19,50 @@ Feature: Check the size of autoloaded transients
     When I run `wp doctor check transients-size --fields=message`
     Then STDOUT should contain:
       """
-      is less than threshold (900kb)
+      does not exceed threshold (900kb)
+      """
+
+  Scenario: Autoloaded transients equal 900 kb
+    Given a WP install
+    And a wp-content/mu-plugins/exact-threshold-transients.php file:
+      """
+      <?php
+      add_action(
+        'wp_loaded',
+        static function () {
+          global $wpdb;
+
+          $option_names = $wpdb->get_col( "SELECT option_name FROM {$wpdb->options}" );
+          foreach ( $option_names as $option_name ) {
+            if (
+              0 === strpos( $option_name, '_transient_' )
+              || 0 === strpos( $option_name, '_site_transient_' )
+            ) {
+              delete_option( $option_name );
+            }
+          }
+
+          add_option( '_transient_doctor_exact_threshold', str_repeat( '9', 900 * 1024 ), '', true );
+        },
+        PHP_INT_MAX
+      );
+      """
+
+    When I run `wp option list --transients --autoload=on --format=total_bytes`
+    Then STDOUT should be:
+      """
+      921600
+      """
+
+    When I run `wp doctor check transients-size --fields=name,status`
+    Then STDOUT should be a table containing rows:
+      | name            | status  |
+      | transients-size | success |
+
+    When I run `wp doctor check transients-size --fields=message`
+    Then STDOUT should contain:
+      """
+      Autoloaded transients size (900kb) does not exceed threshold (900kb).
       """
 
   Scenario: Autoloaded transients are greater than 900 kb
@@ -77,7 +120,7 @@ Feature: Check the size of autoloaded transients
     When I run `wp doctor check transients-size --fields=message --config=custom.yml`
     Then STDOUT should contain:
       """
-      is less than threshold (800kb)
+      does not exceed threshold (800kb)
       """
 
   Scenario: Zero threshold is formatted safely
@@ -109,5 +152,5 @@ Feature: Check the size of autoloaded transients
     When I run `wp doctor check transients-size --fields=message --config=custom.yml`
     Then STDOUT should contain:
       """
-      is less than threshold (1024t)
+      does not exceed threshold (1024t)
       """

--- a/features/check.feature
+++ b/features/check.feature
@@ -160,6 +160,7 @@ Feature: Basic check usage
     Then STDOUT should be a table containing rows:
       | name                  |
       | autoload-options-size |
+      | transients-size       |
       | core-update           |
       | core-verify-checksums |
       | plugin-deactivated    |

--- a/src/Check.php
+++ b/src/Check.php
@@ -88,6 +88,24 @@ abstract class Check {
 	}
 
 	/**
+	 * Format a byte count for check result messages.
+	 *
+	 * @param int|float $size Size in bytes.
+	 * @param int       $precision Precision.
+	 * @return string
+	 */
+	protected static function format_bytes( $size, $precision = 2 ) {
+		if ( 0 >= $size ) {
+			return '0';
+		}
+
+		$suffixes = array( '', 'kb', 'mb', 'g', 't' );
+		$base     = min( (int) floor( log( $size, 1024 ) ), count( $suffixes ) - 1 );
+
+		return round( $size / pow( 1024, $base ), $precision ) . $suffixes[ $base ];
+	}
+
+	/**
 	 * Run the check.
 	 *
 	 * Because each check checks for something different, this method must be

--- a/src/Check/Autoload_Options_Size.php
+++ b/src/Check/Autoload_Options_Size.php
@@ -42,15 +42,4 @@ class Autoload_Options_Size extends Check {
 			$this->set_message( "Autoloaded options size ({$human_total}) is less than threshold ({$human_threshold})." );
 		}
 	}
-
-	/**
-	 * @param int|float $size Size in bytes.
-	 * @param int       $precision Precision.
-	 * @return string
-	 */
-	private static function format_bytes( $size, $precision = 2 ) {
-		$base     = log( $size, 1024 );
-		$suffixes = array( '', 'kb', 'mb', 'g', 't' );
-		return round( pow( 1024, $base - floor( $base ) ), $precision ) . $suffixes[ (int) floor( $base ) ];
-	}
 }

--- a/src/Check/Autoload_Options_Size.php
+++ b/src/Check/Autoload_Options_Size.php
@@ -39,7 +39,7 @@ class Autoload_Options_Size extends Check {
 			$this->set_message( "Autoloaded options size ({$human_total}) exceeds threshold ({$human_threshold})" );
 		} else {
 			$this->set_status( 'success' );
-			$this->set_message( "Autoloaded options size ({$human_total}) is less than threshold ({$human_threshold})." );
+			$this->set_message( "Autoloaded options size ({$human_total}) does not exceed threshold ({$human_threshold})." );
 		}
 	}
 }

--- a/src/Check/Transients_Size.php
+++ b/src/Check/Transients_Size.php
@@ -43,19 +43,4 @@ class Transients_Size extends Check {
 			$this->set_message( "Autoloaded transients size ({$human_total}) is less than threshold ({$human_threshold})." );
 		}
 	}
-
-	/**
-	 * @param int|float $size Size in bytes.
-	 * @param int       $precision Precision.
-	 * @return string
-	 */
-	private static function format_bytes( $size, $precision = 2 ) {
-		if ( 0 >= $size ) {
-			return '0';
-		}
-
-		$base     = log( $size, 1024 );
-		$suffixes = array( '', 'kb', 'mb', 'g', 't' );
-		return round( pow( 1024, $base - floor( $base ) ), $precision ) . $suffixes[ (int) floor( $base ) ];
-	}
 }

--- a/src/Check/Transients_Size.php
+++ b/src/Check/Transients_Size.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace WP_CLI\Doctor\Check;
+
+use WP_CLI;
+use WP_CLI\Doctor\Check;
+
+/**
+ * Warns when autoloaded transients size exceeds threshold of %threshold_kb% kb.
+ */
+class Transients_Size extends Check {
+
+	/**
+	 * Threshold in kilobytes.
+	 *
+	 * @var integer
+	 */
+	protected $threshold_kb = 900;
+
+	/**
+	 * @return void
+	 */
+	public function run() {
+		ob_start();
+		WP_CLI::run_command(
+			array( 'option', 'list' ),
+			array(
+				'transients' => true,
+				'autoload'   => 'on',
+				'format'     => 'total_bytes',
+			)
+		);
+		$total_bytes = (int) ob_get_clean();
+
+		$threshold_bytes = $this->threshold_kb * 1024;
+		$human_threshold = self::format_bytes( $threshold_bytes );
+		$human_total     = self::format_bytes( $total_bytes );
+		if ( $threshold_bytes < $total_bytes ) {
+			$this->set_status( 'warning' );
+			$this->set_message( "Autoloaded transients size ({$human_total}) exceeds threshold ({$human_threshold})" );
+		} else {
+			$this->set_status( 'success' );
+			$this->set_message( "Autoloaded transients size ({$human_total}) is less than threshold ({$human_threshold})." );
+		}
+	}
+
+	/**
+	 * @param int|float $size Size in bytes.
+	 * @param int       $precision Precision.
+	 * @return string
+	 */
+	private static function format_bytes( $size, $precision = 2 ) {
+		if ( 0 >= $size ) {
+			return '0';
+		}
+
+		$base     = log( $size, 1024 );
+		$suffixes = array( '', 'kb', 'mb', 'g', 't' );
+		return round( pow( 1024, $base - floor( $base ) ), $precision ) . $suffixes[ (int) floor( $base ) ];
+	}
+}

--- a/src/Check/Transients_Size.php
+++ b/src/Check/Transients_Size.php
@@ -40,7 +40,7 @@ class Transients_Size extends Check {
 			$this->set_message( "Autoloaded transients size ({$human_total}) exceeds threshold ({$human_threshold})" );
 		} else {
 			$this->set_status( 'success' );
-			$this->set_message( "Autoloaded transients size ({$human_total}) is less than threshold ({$human_threshold})." );
+			$this->set_message( "Autoloaded transients size ({$human_total}) does not exceed threshold ({$human_threshold})." );
 		}
 	}
 }

--- a/src/Command.php
+++ b/src/Command.php
@@ -28,6 +28,7 @@ use WP_CLI\Utils;
  *     | name                       | description                                                                    |
  *     +----------------------------+--------------------------------------------------------------------------------+
  *     | autoload-options-size      | Warns when autoloaded options size exceeds threshold of 900 kb.                |
+ *     | transients-size            | Warns when autoloaded transients size exceeds threshold of 900 kb.             |
  *     | constant-savequeries-falsy | Confirms expected state of the SAVEQUERIES constant.                           |
  *     | constant-wp-debug-falsy    | Confirms expected state of the WP_DEBUG constant.                              |
  *     | core-update                | Errors when new WordPress minor release is available; warns for major release. |
@@ -325,6 +326,7 @@ class Command {
 	 *     | name                       | description                                                                    |
 	 *     +----------------------------+--------------------------------------------------------------------------------+
 	 *     | autoload-options-size      | Warns when autoloaded options size exceeds threshold of 900 kb.                |
+	 *     | transients-size            | Warns when autoloaded transients size exceeds threshold of 900 kb.             |
 	 *     | constant-savequeries-falsy | Confirms expected state of the SAVEQUERIES constant.                           |
 	 *     | constant-wp-debug-falsy    | Confirms expected state of the WP_DEBUG constant.                              |
 	 *     | core-update                | Errors when new WordPress minor release is available; warns for major release. |


### PR DESCRIPTION
## Summary

Adds a separate transients-size check for detecting large autoloaded transients.

Non-expiring transients are autoloaded by WordPress, but they are intentionally excluded from the existing autoload-options-size check. This new check reports them separately, as suggested in the issue.

The check is included in the default Doctor configuration and uses the same configurable 900 KB threshold as the existing autoloaded options check.

## Implementation

The check uses wp option list with the transients, autoload and total_bytes options.

The required filtering was corrected in wp-cli/entity-command#620 and released in Entity Command v2.8.12. The minimum dependency has therefore been updated to ^2.8.12.

## Testing

- Composer validation
- PHP lint
- PHPCS
- PHPStan
- PHPUnit
- Focused Behat scenarios with SQLite and MySQL 8
- Full Doctor Command Behat suite with SQLite
- Manual testing against WordPress with MySQL 8

Fixes #150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `transients-size` check to the default Doctor configuration.
  * Reports whether autoloaded transient data exceeds the recommended 900 KB threshold, with readable sizes and configurable limits.
  * Excludes expiring transients from the measurement.
  * Added the check to Doctor documentation and available check listings.

* **Bug Fixes**
  * Clarified autoloaded options size messages to accurately describe threshold comparisons.

* **Tests**
  * Added coverage for success, warning, exclusions, custom thresholds, and size formatting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->