### PR TITLE
Fix failing theme tests

### DIFF
--- a/features/check-theme-update.feature
+++ b/features/check-theme-update.feature
@@ -20,7 +20,7 @@ Feature: Check whether themes are up to date
   Scenario: One theme has an update available
     Given a WP install
     And I run `wp theme update --all`
-    And I run `wp theme install moina --version=1.1.2`
+    And I run `wp theme install oceanly --version=1.0.0`
 
     When I run `wp doctor check theme-update`
     Then STDOUT should be a table containing rows:

--- a/features/check-theme-update.feature
+++ b/features/check-theme-update.feature
@@ -20,7 +20,7 @@ Feature: Check whether themes are up to date
   Scenario: One theme has an update available
     Given a WP install
     And I run `wp theme update --all`
-    And I run `wp theme install oceanly --version=1.0.0`
+    And I run `wp theme install twentytwelve --version=1.0 --force`
 
     When I run `wp doctor check theme-update`
     Then STDOUT should be a table containing rows:


### PR DESCRIPTION
Replaces `moina` with `oceanly` due to a change in PHP requirements in the former.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the theme update scenario to install the Twenty Twelve theme version 1.0 with force enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->